### PR TITLE
DarkRP 2.6 auto loads all the LUA files now.

### DIFF
--- a/tcb_motd/cl_motd.lua
+++ b/tcb_motd/cl_motd.lua
@@ -6,8 +6,6 @@
 	
 ---------------------------------------------------------------------------*/
 
-include( 'sh_config.lua' );
-
 local function MotdFrame()
 
 	local Frame = vgui.Create( "DFrame" )

--- a/tcb_motd/sv_motd.lua
+++ b/tcb_motd/sv_motd.lua
@@ -6,8 +6,6 @@
 	
 ---------------------------------------------------------------------------*/
 
-include( 'sh_config.lua' );
-
 -- Player Spawn
 local function OpenMotdOnJoin( ply )
 


### PR DESCRIPTION
This made "include( 'sh_config.lua' );" obsolete and crash the script, giving a "File not found" error.
